### PR TITLE
CALCLY-1319 - validate endpoint fix

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -84,11 +84,13 @@ class Client
             RequestMethod::METHOD_POST,
             $endpoint,
             $this->buildHeaders(),
-            [
-                "client_id" => $id,
-                "client_secret" => $secret,
-                "scope" => $scope,
-            ]
+            json_encode(
+                [
+                    "client_id" => $id,
+                    "client_secret" => $secret,
+                    "scope" => $scope,
+                ]
+            )
         );
         $response = $this->sendRequest($request);
 
@@ -125,9 +127,11 @@ class Client
             RequestMethod::METHOD_POST,
             $endpoint,
             $this->buildHeaders(),
-            [
-                "access_token" => $accessToken,
-            ]
+            json_encode(
+                [
+                    "access_token" => $accessToken,
+                ]
+            ),
         );
         $response = $this->sendRequest($request);
 


### PR DESCRIPTION
It looks like noone have ever used `validate()` method, as it was wrongly prepared and was trying to sent array instead of string:

```
InvalidArgumentException: Invalid resource type: array in file /application/vendor/guzzlehttp/psr7/src/Utils.php on line 337

#0 /application/vendor/guzzlehttp/psr7/src/Request.php(57): GuzzleHttp\Psr7\Utils::streamFor(Array)
#1 /application/vendor/insly/identifier-service-phpclient/src/Client.php(129): GuzzleHttp\Psr7\Request->__construct('POST', Object(GuzzleHttp\Psr7\Uri), Array, Array)
#2 /application/app/Services/Authorization/IdentifierService.php(21): Insly\Identifier\Client\Client->validate('eyJraWQiOiJFc29...')
#3 /application/app/Http/Middleware/IdentifyRequest.php(34): Insly\PolishCompanies\Services\Authorization\IdentifierService->authorize('eyJraWQiOiJFc29...')
```

With this PR it should be fixed.