### PR TITLE
- missing http foundation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
   ],
   "require": {
     "php": "^8.0",
-    "guzzlehttp/guzzle": "^7.2"
+    "guzzlehttp/guzzle": "^7.2",
+    "symfony/http-foundation": "^5.3"
   },
   "require-dev": {
     "blumilksoftware/codestyle": "^0.4",


### PR DESCRIPTION
`symfony/http-foundation` was missing, so tests on the new instance weren't passing. It's not a problem when it's used with the framework, because Laravel already requires this package, but it should be fixed anyway.