### PR TITLE
Allow login with runtime credentials with additional meta info

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -37,17 +37,31 @@ class Client
     }
 
     /**
-     * @throws ClientExceptionInterface
      * @throws ExtractResponseException
      * @throws IdentifierServiceClientException
      * @throws JsonException
      */
     public function login(): ResponseInterface
     {
+        return $this->loginWithPassword(
+            $this->config->getUsername(),
+            $this->config->getPassword(),
+            $this->config->getLoginMeta(),
+        );
+    }
+
+    /**
+     * @throws ExtractResponseException
+     * @throws IdentifierServiceClientException
+     * @throws JsonException
+     */
+    public function loginWithPassword(string $username, string $password, array $meta): ResponseInterface
+    {
         $endpoint = $this->config->getHost() . "login/" . $this->config->getTenant();
         $credentials = [
-            "username" => $this->config->getUsername(),
-            "password" => $this->config->getPassword(),
+            "username" => $username,
+            "password" => $password,
+            "meta_data" => $meta,
         ];
 
         $request = new Request(RequestMethod::METHOD_POST, $endpoint, [], json_encode($credentials, flags: JSON_THROW_ON_ERROR));

--- a/src/Config.php
+++ b/src/Config.php
@@ -11,6 +11,7 @@ class Config
     protected string $token = "";
     protected string $username = "";
     protected string $password = "";
+    protected array $loginMeta = [];
 
     public function __construct(string $host, string $tenant)
     {
@@ -70,5 +71,15 @@ class Config
     public function setUsername(string $username): void
     {
         $this->username = $username;
+    }
+
+    public function getLoginMeta(): array
+    {
+        return $this->loginMeta;
+    }
+
+    public function setLoginMeta(array $meta): void
+    {
+        $this->loginMeta = $meta;
     }
 }

--- a/src/DTO/IdentifierService/IdentifierErrorResponse.php
+++ b/src/DTO/IdentifierService/IdentifierErrorResponse.php
@@ -18,7 +18,7 @@ class IdentifierErrorResponse
     }
 
     /**
-     * @return Error[]
+     * @return array<Error>
      */
     public function getErrors(): array
     {

--- a/src/Testing/RequestMocks.php
+++ b/src/Testing/RequestMocks.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Insly\Identifier\Client\Testing;
+
+class RequestMocks
+{
+    public static function getLogin(string $username, string $password, array $meta): array
+    {
+        return [
+            "username" => $username,
+            "password" => $password,
+            "meta_data" => $meta,
+        ];
+    }
+}


### PR DESCRIPTION
Allow login with runtime credentials with additional meta info

Login credentials are pre-configured in Config, which does not provide 
modification during runtime. 

https://app.beta.insly.training/api/v1/identifier/doc/swagger/index.html
POST /login/{tenant_tag}

INSLYPROD-3037