### PR TITLE
- fix string interpolation deprecated warning

### DIFF
--- a/src/Exceptions/IdentifierServiceClientException.php
+++ b/src/Exceptions/IdentifierServiceClientException.php
@@ -19,7 +19,7 @@ class IdentifierServiceClientException extends Exception
     public function setDetails(array $details): static
     {
         $detailsJson = json_encode($details, flags: JSON_THROW_ON_ERROR);
-        $this->message .= " [Details: ${detailsJson}]";
+        $this->message .= " [Details: {$detailsJson}]";
 
         return $this;
     }

--- a/tests/mocked/ClientTest.php
+++ b/tests/mocked/ClientTest.php
@@ -93,7 +93,7 @@ class ClientTest extends TestCase
     {
         foreach ($expectedHeaders as $headerName => $headerValue) {
             $this->assertArrayHasKey($headerName, $preparedHeaders);
-            $this->assertSame($headerValue, $preparedHeaders[$headerName], "Expected value (${headerValue}) for header (${headerName}) is not the same as (${preparedHeaders[$headerName]})");
+            $this->assertSame($headerValue, $preparedHeaders[$headerName], "Expected value ({$headerValue}) for header ({$headerName}) is not the same as ({$preparedHeaders[$headerName]})");
         }
     }
 }

--- a/tests/mocked/ErrorResponseHandlerTest.php
+++ b/tests/mocked/ErrorResponseHandlerTest.php
@@ -94,7 +94,7 @@ class ErrorResponseHandlerTest extends TestCase
     {
         $this->expectException($exceptionClass);
         // check if errorCode exists in the exception message
-        $errorCodeRegex = "/${errorCode}/";
+        $errorCodeRegex = "/{$errorCode}/";
         $this->expectExceptionMessageMatches($errorCodeRegex);
 
         $response = new Response(status: 400, body: json_encode($responseArray));


### PR DESCRIPTION
This PR fixes depricated warnings for PHP 8.2. 
After this change, project which use this library will be able to update PHP to 8.2.