### PR TITLE
INS-494 Add forcePasswordReset endpoint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": "^8.0",
     "guzzlehttp/guzzle": "^7.4",
-    "symfony/http-foundation": "^5.4|^6.0"
+    "symfony/http-foundation": "^5.4|^6.0|^7.0"
   },
   "require-dev": {
     "blumilksoftware/codestyle": "^1.6.0",

--- a/src/Client.php
+++ b/src/Client.php
@@ -201,7 +201,7 @@ class Client
      * @throws JsonException
      * @throws NoTokenException
      */
-    public function forcePasswordReset(string $username): void
+    public function forcePasswordReset(string $username): array
     {
         $this->validateToken();
 
@@ -220,8 +220,9 @@ class Client
 
         $response = $this->sendRequest($request);
         $this->validateResponse($response);
-    }
 
+        return $this->extractResponse($response);
+    }
 
     protected function buildHeaders(array $headers = []): array
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -201,7 +201,7 @@ class Client
      * @throws JsonException
      * @throws NoTokenException
      */
-    public function forcePasswordReset(string $username): array
+    public function forcePasswordReset(string $username): void
     {
         $this->validateToken();
 
@@ -220,8 +220,6 @@ class Client
 
         $response = $this->sendRequest($request);
         $this->validateResponse($response);
-
-        return $this->extractResponse($response);
     }
 
     protected function buildHeaders(array $headers = []): array

--- a/src/Client.php
+++ b/src/Client.php
@@ -51,6 +51,7 @@ class Client
     }
 
     /**
+     * @throws ClientExceptionInterface
      * @throws ExtractResponseException
      * @throws IdentifierServiceClientException
      * @throws JsonException
@@ -133,10 +134,13 @@ class Client
             RequestMethod::METHOD_POST,
             $endpoint,
             $this->buildHeaders(),
-            [
-                "refresh_token" => $refreshToken,
-                "username" => $username,
-            ],
+            json_encode(
+                [
+                    "refresh_token" => $refreshToken,
+                    "username" => $username,
+                ],
+                flags: JSON_THROW_ON_ERROR,
+            ),
         );
         $response = $this->sendRequest($request);
         $this->validateResponse($response);
@@ -206,9 +210,12 @@ class Client
             RequestMethod::METHOD_POST,
             $endpoint,
             $this->buildHeaders(),
-            \GuzzleHttp\json_encode([
-                "Username" => $username,
-            ])
+            json_encode(
+                [
+                    "Username" => $username,
+                ],
+                flags: JSON_THROW_ON_ERROR,
+            )
         );
 
         $response = $this->sendRequest($request);

--- a/src/Client.php
+++ b/src/Client.php
@@ -215,7 +215,7 @@ class Client
                     "Username" => $username,
                 ],
                 flags: JSON_THROW_ON_ERROR,
-            )
+            ),
         );
 
         $response = $this->sendRequest($request);

--- a/src/Client.php
+++ b/src/Client.php
@@ -190,6 +190,32 @@ class Client
         return UserBuilder::buildFromResponse($this->extractResponse($response));
     }
 
+    /**
+     * @throws ClientExceptionInterface
+     * @throws ExtractResponseException
+     * @throws IdentifierServiceClientException
+     * @throws JsonException
+     * @throws NoTokenException
+     */
+    public function forcePasswordReset(string $username): void
+    {
+        $this->validateToken();
+
+        $endpoint = $this->config->getHost() . "password/force_reset/" . $this->config->getTenant();
+        $request = new Request(
+            RequestMethod::METHOD_POST,
+            $endpoint,
+            $this->buildHeaders(),
+            \GuzzleHttp\json_encode([
+                "Username" => $username,
+            ])
+        );
+
+        $response = $this->sendRequest($request);
+        $this->validateResponse($response);
+    }
+
+
     protected function buildHeaders(array $headers = []): array
     {
         return array_merge(


### PR DESCRIPTION
Created `Client::forcePasswordReset` method which resets users password and sends an email with instructions.

Used at Insly 3 on user profile page.

Also:
* Added `symfony/http-foundation` ^7.0 support for compatibility with Laravel 11.
* Fixed body parameter at `Client::refresh` method.